### PR TITLE
FOLIO-722 minor tidy for initial repo setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contribution guidelines
+
+Guidelines for Contributing Code:
+[dev.folio.org/guidelines/contributing](https://dev.folio.org/guidelines/contributing)

--- a/MODEL.md
+++ b/MODEL.md
@@ -27,7 +27,7 @@ an item reserved to a section of a course. Consists primarily of a `sectionId` a
 
 * `role.json`
 --
-an entry in the very simple controlled vocabulary of roles that instructors can take (e.g. "principal instructor", "teaching assisant", "lab support").
+an entry in the very simple controlled vocabulary of roles that instructors can take (e.g. "principal instructor", "teaching assistant", "lab support").
 [[Example]](ramls/examples/role.json)
 
 * `schedule.json`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Backend CRUD storage module to support the Course Reserves functionality
 
 Other [modules](https://dev.folio.org/source-code/#client-side).
 
-See project [UIC](https://issues.folio.org/browse/UIC)
+See project [MODCR](https://issues.folio.org/browse/MODCR)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
 Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)

--- a/src/main/java/org/folio/rest/impl/CourseAPI.java
+++ b/src/main/java/org/folio/rest/impl/CourseAPI.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.folio.rest.impl;
 
 import io.vertx.core.AsyncResult;


### PR DESCRIPTION
Added missing CONTRIBUTING.md

Please fix IDE. We do not use license headers in source code files.
See https://dev.folio.org/guidelines/contributing/#no-license-header


I noticed a couple of other things:

The MODEL.md document "APIs" section refers to RAMLs that seem to have been removed.

Also in MODEL.md document, the explanation of "schedule.json" is confusing about "sections".
Similarly with its description in the schema file.
