### PR TITLE
FOLIO-2238 Add missing LaunchDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -182,5 +182,12 @@
             ]
         }
     ],
-    "permissionSets": []
+    "permissionSets": [],
+    "launchDescriptor": {
+        "dockerImage": "${artifactId}:${version}",
+        "dockerArgs": {
+            "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
+        },
+        "dockerPull" : false
+    }
 }


### PR DESCRIPTION
As per other mod-* folio-org modules. Copied from mod-notes.