### PR TITLE
Add `additionalSectionsUsed` field to copyrightTracking

### DIFF
--- a/ramls/reserve.json
+++ b/ramls/reserve.json
@@ -142,6 +142,10 @@
             "type": "object",
             "description": "Information about copyright status, volume of material used, etc.",
             "properties": {
+                "additionalSectionsUsed": {
+                    "type": "boolean",
+                    "description": "Additional sections of this item used in this course"
+                },
                 "copyrightStatusId": {
                     "type": "string",
                     "description": "The id of the copyright status",


### PR DESCRIPTION
I don't know how we missed this, but we need this boolean field in the
copyright-tracking subrecord, as described in UICR-9.