### PR TITLE
Simplify reserves records to be added to database

### DIFF
--- a/src/main/resources/sample-data/reserves/Reserve000.json
+++ b/src/main/resources/sample-data/reserves/Reserve000.json
@@ -1,37 +1,7 @@
 {
   "id": "67227d94-7333-4d22-98a0-718b49d36595",
   "courseListingId": "c03bcba3-a6a0-4251-b316-0631bb2e6f21",
-  "itemId": "23fdb0bc-ab58-442a-b326-577a96204487",
-  "processingStatusId": "8bf28ac6-accd-4575-8ffa-365850be1851",
   "copiedItem": {
-    "barcode": "653285216743",
-    "temporaryLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",
-    "callNumber": "some-callnumber",
-    "title": "A semantic web primer",
-    "contributors": [
-      {
-        "name": "Grigoris Antoniou"
-      },
-      {
-        "name": "Paul Groth"
-      },
-      {
-        "name": "Frank van Harmelen"
-      },
-      {
-        "name": "Rinke Hoekstra"
-      }
-    ],
-    "copy": "sole copy",
-    "enumeration": "3 of 6",
-    "url": "http://svpow.com/"
-  },
-  "temporaryLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
-  "copyrightTracking": {
-    "copyrightStatusId": "04521370-886e-41de-afbe-55a8b9fe782a",
-    "totalPagesInItem": "288",
-    "totalPagesUsed": "11",
-    "percentOfPages": "4%",
-    "paymentBasis": "unspecified"
+    "barcode": "90000"
   }
 }

--- a/src/main/resources/sample-data/reserves/Reserve001.json
+++ b/src/main/resources/sample-data/reserves/Reserve001.json
@@ -1,25 +1,7 @@
 {
   "id": "58e857de-0d18-46d0-b607-781e180ce95c",
   "courseListingId": "1049e672-dcde-4c7c-b95b-edf9f60c6cbd",
-  "itemId": "61bcef78-0001-11ea-ae82-fbccb479e70f",
-  "processingStatusId": "8bf28ac6-accd-4575-8ffa-365850be1851",
   "copiedItem": {
-    "barcode": "0114401282342",
-    "temporaryLocationId": "01096259-c643-493c-8693-e5f00c0ef89c",
-    "callNumber": "call123-A",
-    "title": "Invertebrate paleontology",
-    "contributors": [
-      {
-        "name": "Easton, William H. (William Heyden), 1916-1996"
-      }
-    ]
-  },
-  "temporaryLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
-  "copyrightTracking": {
-    "copyrightStatusId": "04521370-886e-41de-afbe-55a8b9fe782a",
-    "totalPagesInItem": "701",
-    "totalPagesUsed": "11",
-    "percentOfPages": "2%",
-    "paymentBasis": "unspecified"
+    "barcode": "4539876054383"
   }
 }


### PR DESCRIPTION
Previously we were adding complete records with an `itemId`, `copiedItem`, etc. All we need to POST is the `id`, `courseListingId` and `copiedItem.barcode`, and the course-reserves module's logic will pull in the item.

I am not 100% sure that these records will do what we want, because I have not been able to load them against an empty database. But I think they will, and we will find out on tonight's rebuild.