### PR TITLE
MODCR-25: Fix extra generated Java source files with just name case difference

### DIFF
--- a/ramls/copyrightstatuses.json
+++ b/ramls/copyrightstatuses.json
@@ -5,7 +5,7 @@
     "properties": {
         "copyrightStatuses": {
             "description": "List of copyright statuses",
-            "id": "copyrightStatuses",
+            "id": "copyrightStatus",
             "type": "array",
             "items": {
                 "type": "object",

--- a/ramls/courselistings.json
+++ b/ramls/courselistings.json
@@ -5,7 +5,7 @@
     "properties": {
         "courseListings": {
             "description": "List of course listing records",
-            "id": "courseListings",
+            "id": "courseListing",
             "type": "array",
             "items": {
                 "type": "object",

--- a/ramls/courses.raml
+++ b/ramls/courses.raml
@@ -13,8 +13,8 @@ documentation:
 types:
     course: !include course.json
     courses: !include courses.json
-    courselisting: !include courselisting.json
-    courselistings: !include courselistings.json
+    courseListing: !include courselisting.json
+    courseListings: !include courselistings.json
     instructor: !include instructor.json
     instructors: !include instructors.json
     reserve: !include reserve.json
@@ -23,14 +23,14 @@ types:
     roles: !include roles.json
     term: !include term.json
     terms: !include terms.json
-    coursetype: !include coursetype.json
-    coursetypes: !include coursetypes.json
+    courseType: !include coursetype.json
+    courseTypes: !include coursetypes.json
     department: !include department.json
     departments: !include departments.json
-    processingstatus: !include processingstatus.json
-    processingstatuses: !include processingstatuses.json
-    copyrightstatus: !include copyrightstatus.json
-    copyrightstatuses: !include copyrightstatuses.json
+    processingStatus: !include processingstatus.json
+    processingStatuses: !include processingstatuses.json
+    copyrightStatus: !include copyrightstatus.json
+    copyrightStatuses: !include copyrightstatuses.json
     errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -51,8 +51,8 @@ resourceTypes:
             collection:
                 exampleCollection: !include examples/courselistings.json
                 exampleItem: !include examples/courselisting.json
-                schemaCollection: courselistings
-                schemaItem: courselisting
+                schemaCollection: courseListings
+                schemaItem: courseListing
         get:
             description: "Return a list of listings"
             is: [
@@ -78,7 +78,7 @@ resourceTypes:
             type:
                 collection-item:
                     exampleItem: !include examples/courselisting.json
-                    schema: courselisting
+                    schema: courseListing
             get:
             put:
                 description: "Update a listing by id"
@@ -289,8 +289,8 @@ resourceTypes:
             collection:
                 exampleCollection: !include examples/coursetypes.json
                 exampleItem: !include examples/coursetype.json
-                schemaCollection: coursetypes
-                schemaItem: coursetype
+                schemaCollection: courseTypes
+                schemaItem: courseType
         get:
             description: "Return a list of course types"
             is: [
@@ -316,7 +316,7 @@ resourceTypes:
             type:
                 collection-item:
                     exampleItem: !include examples/coursetype.json
-                    schema: coursetype
+                    schema: courseType
             get:
             put:
                 description: "Update a course type by id"
@@ -367,8 +367,8 @@ resourceTypes:
             collection:
                 exampleCollection: !include examples/processingstatuses.json
                 exampleItem: !include examples/processingstatus.json
-                schemaCollection: processingstatuses
-                schemaItem: processingstatus
+                schemaCollection: processingStatuses
+                schemaItem: processingStatus
         get:
             description: "Return a list of statuses"
             is: [
@@ -394,7 +394,7 @@ resourceTypes:
             type:
                 collection-item:
                     exampleItem: !include examples/processingstatus.json
-                    schema: processingstatus
+                    schema: processingStatus
             get:
             put:
                 description: "Update a status by id"
@@ -406,8 +406,8 @@ resourceTypes:
             collection:
                 exampleCollection: !include examples/copyrightstatuses.json
                 exampleItem: !include examples/copyrightstatus.json
-                schemaCollection: copyrightstatuses
-                schemaItem: copyrightstatus
+                schemaCollection: copyrightStatuses
+                schemaItem: copyrightStatus
         get:
             description: "Return a list of copyright statuses"
             is: [
@@ -433,7 +433,7 @@ resourceTypes:
             type:
                 collection-item:
                     exampleItem: !include examples/copyrightstatus.json
-                    schema: copyrightstatus
+                    schema: copyrightStatus
             get:
             put:
                 description: "Update a status by id"

--- a/ramls/coursetypes.json
+++ b/ramls/coursetypes.json
@@ -5,7 +5,7 @@
     "properties": {
         "courseTypes": {
             "description": "List of course types",
-            "id": "courseTypes",
+            "id": "courseType",
             "type": "array",
             "items": {
                 "type": "object",

--- a/ramls/processingstatuses.json
+++ b/ramls/processingstatuses.json
@@ -5,7 +5,7 @@
     "properties": {
         "processingStatuses": {
             "description": "List of processing status records",
-            "id": "processingStatuses",
+            "id": "processingStatus",
             "type": "array",
             "items": {
                 "type": "object",

--- a/src/main/java/org/folio/rest/impl/CourseAPI.java
+++ b/src/main/java/org/folio/rest/impl/CourseAPI.java
@@ -16,21 +16,21 @@ import org.folio.coursereserves.util.CRUtil;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
-import org.folio.rest.jaxrs.model.Copyrightstatus;
-import org.folio.rest.jaxrs.model.Copyrightstatuses;
+import org.folio.rest.jaxrs.model.CopyrightStatus;
+import org.folio.rest.jaxrs.model.CopyrightStatuses;
 import org.folio.rest.jaxrs.model.Course;
-import org.folio.rest.jaxrs.model.Courselisting;
-import org.folio.rest.jaxrs.model.Courselistings;
+import org.folio.rest.jaxrs.model.CourseListing;
+import org.folio.rest.jaxrs.model.CourseListings;
 import org.folio.rest.jaxrs.model.Courses;
-import org.folio.rest.jaxrs.model.Coursetype;
-import org.folio.rest.jaxrs.model.Coursetypes;
+import org.folio.rest.jaxrs.model.CourseType;
+import org.folio.rest.jaxrs.model.CourseTypes;
 import org.folio.rest.jaxrs.model.Department;
 import org.folio.rest.jaxrs.model.Departments;
 import org.folio.rest.jaxrs.model.Instructor;
 import org.folio.rest.jaxrs.model.Instructors;
 import org.folio.rest.jaxrs.model.PatronGroupObject;
-import org.folio.rest.jaxrs.model.Processingstatus;
-import org.folio.rest.jaxrs.model.Processingstatuses;
+import org.folio.rest.jaxrs.model.ProcessingStatus;
+import org.folio.rest.jaxrs.model.ProcessingStatuses;
 import org.folio.rest.jaxrs.model.Reserve;
 import org.folio.rest.jaxrs.model.Reserves;
 import org.folio.rest.jaxrs.model.Role;
@@ -51,10 +51,10 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 
 public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
-  
+
   public static final Logger logger = LoggerFactory.getLogger(
           CourseAPI.class);
-  
+
   public static final String COURSES_TABLE = "coursereserves_courses";
   public static final String COURSE_LISTINGS_TABLE = "coursereserves_courselistings";
   public static final String RESERVES_TABLE = "coursereserves_reserves";
@@ -76,9 +76,9 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public static final String DEPARTMENTS_PREFIX = "/departments";
   public static final String ROLES_PREFIX = "/roles";
   public static final String ID_FIELD = "'id'";
-  
+
   private static boolean SUPPRESS_ERRORS = false;
-  
+
 
   public PostgresClient getPGClient(Context vertxContext, String tenantId) {
     return PostgresClient.getInstance(vertxContext.owner(), tenantId);
@@ -149,13 +149,13 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
       String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
-    PgUtil.get(COURSE_LISTINGS_TABLE, Courselisting.class, Courselistings.class,
+    PgUtil.get(COURSE_LISTINGS_TABLE, CourseListing.class, CourseListings.class,
         query, offset, limit, okapiHeaders, vertxContext,
         GetCoursereservesCourselistingsResponse.class, asyncResultHandler);
   }
 
   @Override
-  public void postCoursereservesCourselistings(String lang, Courselisting entity,
+  public void postCoursereservesCourselistings(String lang, CourseListing entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(COURSE_LISTINGS_TABLE, entity, okapiHeaders, vertxContext,
@@ -214,7 +214,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
 
   @Override
   public void putCoursereservesCourselistingsByListingId(String listingId,
-      String lang, Courselisting entity, Map<String, String> okapiHeaders,
+      String lang, CourseListing entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(COURSE_LISTINGS_TABLE, entity, listingId, okapiHeaders, vertxContext,
         PutCoursereservesCourselistingsByListingIdResponse.class, asyncResultHandler);
@@ -413,7 +413,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
             });
           }
         });
-      
+
       });
     }
   }
@@ -484,7 +484,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
         });
       }
     });
-      
+
   }
 
   @Override
@@ -636,7 +636,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
                  .respond500WithTextPlain(getErrorResponse(message))));
            }
           }
-        }); 
+        });
       } catch(Exception e) {
         String message = logAndSaveError(e);
         asyncResultHandler.handle(Future.succeededFuture(
@@ -787,7 +787,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   }
 
   @Override
-  public void putCoursereservesRolesByRoleId(String roleId, String lang, 
+  public void putCoursereservesRolesByRoleId(String roleId, String lang,
       Role entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(ROLES_TABLE, entity, roleId, okapiHeaders, vertxContext,
@@ -812,7 +812,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   }
 
   @Override
-  public void postCoursereservesTerms(String lang, Term entity, 
+  public void postCoursereservesTerms(String lang, Term entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(TERMS_TABLE, entity, okapiHeaders, vertxContext,
@@ -876,13 +876,13 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public void getCoursereservesCoursetypes(String query, int offset, int limit,
       String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.get(COURSE_TYPES_TABLE, Coursetype.class, Coursetypes.class, query,
+    PgUtil.get(COURSE_TYPES_TABLE, CourseType.class, CourseTypes.class, query,
         offset, limit, okapiHeaders, vertxContext,
         GetCoursereservesCoursetypesResponse.class, asyncResultHandler);
   }
 
   @Override
-  public void postCoursereservesCoursetypes(String lang, Coursetype entity,
+  public void postCoursereservesCoursetypes(String lang, CourseType entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(COURSE_TYPES_TABLE, entity, okapiHeaders, vertxContext,
@@ -922,14 +922,14 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public void getCoursereservesCoursetypesByTypeId(String typeId, String lang,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.getById(COURSE_TYPES_TABLE, Coursetype.class, typeId, okapiHeaders,
+    PgUtil.getById(COURSE_TYPES_TABLE, CourseType.class, typeId, okapiHeaders,
         vertxContext, GetCoursereservesCoursetypesByTypeIdResponse.class,
         asyncResultHandler);
   }
 
   @Override
   public void putCoursereservesCoursetypesByTypeId(String typeId, String lang,
-      Coursetype entity, Map<String, String> okapiHeaders,
+      CourseType entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(COURSE_TYPES_TABLE, entity, typeId, okapiHeaders, vertxContext,
         PutCoursereservesCoursetypesByTypeIdResponse.class, asyncResultHandler);
@@ -1020,14 +1020,14 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public void getCoursereservesProcessingstatuses(String query, int offset,
       int limit, String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.get(PROCESSING_STATUSES_TABLE, Processingstatus.class, Processingstatuses.class,
+    PgUtil.get(PROCESSING_STATUSES_TABLE, ProcessingStatus.class, ProcessingStatuses.class,
         query, offset, limit, okapiHeaders, vertxContext,
         GetCoursereservesProcessingstatusesResponse.class, asyncResultHandler);
   }
 
   @Override
-  public void postCoursereservesProcessingstatuses(String lang, 
-      Processingstatus entity, Map<String, String> okapiHeaders,
+  public void postCoursereservesProcessingstatuses(String lang,
+      ProcessingStatus entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(PROCESSING_STATUSES_TABLE, entity, okapiHeaders, vertxContext,
         PostCoursereservesProcessingstatusesResponse.class, asyncResultHandler);
@@ -1067,7 +1067,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public void getCoursereservesProcessingstatusesByStatusId(String statusId,
       String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.getById(PROCESSING_STATUSES_TABLE, Processingstatus.class, statusId,
+    PgUtil.getById(PROCESSING_STATUSES_TABLE, ProcessingStatus.class, statusId,
         okapiHeaders, vertxContext,
         GetCoursereservesProcessingstatusesByStatusIdResponse.class,
         asyncResultHandler);
@@ -1075,7 +1075,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
 
   @Override
   public void putCoursereservesProcessingstatusesByStatusId(String statusId,
-      String lang, Processingstatus entity,
+      String lang, ProcessingStatus entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(PROCESSING_STATUSES_TABLE, entity, statusId, okapiHeaders,
@@ -1093,17 +1093,17 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   }
 
   @Override
-  public void getCoursereservesCopyrightstatuses(String query, int offset, 
+  public void getCoursereservesCopyrightstatuses(String query, int offset,
       int limit, String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.get(COPYRIGHT_STATUSES_TABLE, Copyrightstatus.class, Copyrightstatuses.class,
+    PgUtil.get(COPYRIGHT_STATUSES_TABLE, CopyrightStatus.class, CopyrightStatuses.class,
         query, offset, limit, okapiHeaders, vertxContext,
         GetCoursereservesCopyrightstatusesResponse.class, asyncResultHandler);
   }
 
   @Override
-  public void postCoursereservesCopyrightstatuses(String lang, 
-      Copyrightstatus entity, Map<String, String> okapiHeaders,
+  public void postCoursereservesCopyrightstatuses(String lang,
+      CopyrightStatus entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(COPYRIGHT_STATUSES_TABLE, entity, okapiHeaders, vertxContext,
         PostCoursereservesCopyrightstatusesResponse.class, asyncResultHandler);
@@ -1142,7 +1142,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
   public void getCoursereservesCopyrightstatusesByStatusId(String statusId,
       String lang, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.getById(COPYRIGHT_STATUSES_TABLE, Copyrightstatus.class, statusId,
+    PgUtil.getById(COPYRIGHT_STATUSES_TABLE, CopyrightStatus.class, statusId,
         okapiHeaders, vertxContext,
         GetCoursereservesCopyrightstatusesByStatusIdResponse.class,
         asyncResultHandler);
@@ -1150,7 +1150,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
 
   @Override
   public void putCoursereservesCopyrightstatusesByStatusId(String statusId,
-      String lang, Copyrightstatus entity, Map<String, String> okapiHeaders,
+      String lang, CopyrightStatus entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(COPYRIGHT_STATUSES_TABLE, entity, statusId, okapiHeaders,
         vertxContext, PutCoursereservesCopyrightstatusesByStatusIdResponse.class,
@@ -1406,8 +1406,8 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
     });
     return future;
  }
-  
-  public Future<Void> deleteAllItems(String tableName, String whereClause, 
+
+  public Future<Void> deleteAllItems(String tableName, String whereClause,
       Map<String, String> okapiHeaders, Context vertxContext) {
     Future future = Future.future();
     try {

--- a/src/test/java/org/folio/coursereserves/util/UtilVertxTest.java
+++ b/src/test/java/org/folio/coursereserves/util/UtilVertxTest.java
@@ -8,8 +8,8 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.UUID;
 import org.folio.rest.jaxrs.model.CopiedItem;
 import org.folio.rest.jaxrs.model.CopyrightTracking;
-import org.folio.rest.jaxrs.model.Copyrightstatus;
-import org.folio.rest.jaxrs.model.Processingstatus;
+import org.folio.rest.jaxrs.model.CopyrightStatus;
+import org.folio.rest.jaxrs.model.ProcessingStatus;
 import org.folio.rest.jaxrs.model.Reserve;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,12 +31,12 @@ public class UtilVertxTest {
           Future.succeededFuture(new JsonObject().put("id", UUID.randomUUID().toString()));
       Future<JsonObject> permLocationFuture =
           Future.succeededFuture(new JsonObject().put("id", UUID.randomUUID().toString()));
-      Processingstatus ps = new Processingstatus();
+      ProcessingStatus ps = new ProcessingStatus();
       ps.setId(UUID.randomUUID().toString());
-      Future<Processingstatus> processingStatusFuture = Future.succeededFuture(ps);
-      Copyrightstatus cs = new Copyrightstatus();
+      Future<ProcessingStatus> processingStatusFuture = Future.succeededFuture(ps);
+      CopyrightStatus cs = new CopyrightStatus();
       cs.setId(UUID.randomUUID().toString());
-      Future<Copyrightstatus> copyrightStatusFuture = Future.succeededFuture(cs);
+      Future<CopyrightStatus> copyrightStatusFuture = Future.succeededFuture(cs);
       Future<JsonObject> loanTypeFuture =
           Future.succeededFuture(new JsonObject().put("id", UUID.randomUUID().toString()));
       CRUtil.populateReserve(reserve, tempLocationFuture, permLocationFuture,
@@ -68,12 +68,12 @@ public class UtilVertxTest {
           Future.failedFuture("Failed location");
       Future<JsonObject> permLocationFuture =
           Future.failedFuture("Failed location");
-      Processingstatus ps = new Processingstatus();
+      ProcessingStatus ps = new ProcessingStatus();
       ps.setId(UUID.randomUUID().toString());
-      Future<Processingstatus> processingStatusFuture = Future.failedFuture("Failed status");
-      Copyrightstatus cs = new Copyrightstatus();
+      Future<ProcessingStatus> processingStatusFuture = Future.failedFuture("Failed status");
+      CopyrightStatus cs = new CopyrightStatus();
       cs.setId(UUID.randomUUID().toString());
-      Future<Copyrightstatus> copyrightStatusFuture = Future.failedFuture("Failed status");
+      Future<CopyrightStatus> copyrightStatusFuture = Future.failedFuture("Failed status");
       Future<JsonObject> loanTypeFuture =
           Future.failedFuture("Failed loantype");
       CRUtil.populateReserve(reserve, tempLocationFuture, permLocationFuture,


### PR DESCRIPTION
See https://issues.folio.org/browse/MODCR-25

Tried to build mod-course on Mac laptop but failed with errors like
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project mod-courses: Compilation failure: Compilation failure: 
[ERROR] /Users/hji/dev/work/tmp/test/mod-courses/target/generated-sources/raml-jaxrs/org/folio/rest/jaxrs/model/Copyrightstatuses.java:[39,18] cannot find symbol
[ERROR]   symbol:   class CopyrightStatus
```
It turns out that there are similar Java source files generated with just case difference in the name. See below examples. Mac is not case sensitive so some files are overwritten. Those extra files can be removed by tweaking the RAML and json files. This PR addresses that to keep things a bit cleaner.
```
Copyrightstatus.java and CopyrightStatus.java, 
Courselisting.java and CourseListing.java
Coursetype.java and CourseType.java
Processingstatus.java and ProcessingStatus.java
```
I also noticed there are similar (same) objects generated and sed in the project. For example, `CourseType.java and CourseTypeObject.java`. They look to be exact same, so maybe that an be cleaned up as well.