### PR TITLE
POST reserves to correct URL within courselisting

### DIFF
--- a/src/main/resources/sample-data/create-records
+++ b/src/main/resources/sample-data/create-records
@@ -8,15 +8,15 @@ set -a
 set +a
 
 for dir in `echo '
-    roles
-    terms
-    coursetypes
-    departments
-    processingstatuses
-    copyrightstatuses
-    courselistings
-    courses
-    instructors
+#    roles
+#    terms
+#    coursetypes
+#    departments
+#    processingstatuses
+#    copyrightstatuses
+#    courselistings
+#    courses
+#    instructors
     reserves
 ' | grep -v '^[ ]*#'`;
     do
@@ -26,7 +26,7 @@ for dir in `echo '
 	    path=$dir
 	    echo
 	    echo "  Adding $dir '$file' at /$path"
-	    if [ $dir = instructors ]; then
+	    if [ $dir = instructors -o $dir = reserves ]; then
 		clid=`sed -n 's/^  "courseListingId": "\(.*\)",*/\1/p	' $file`
 		if [ "x$clid" != x ]; then
 		    path=courselistings/$clid/${path}


### PR DESCRIPTION
Previously we were POSTing the sample reserves to `/coursereserves/reserves`. Now we are correctly interpolating the courselisting ID to yield paths like `/coursereserves/courselistings/c03bcba3-a6a0-4251-b316-0631bb2e6f21/reserves`.
