### PR TITLE
Remove the *&^&*^ing comment signs from create-records

### DIFF
--- a/src/main/resources/sample-data/create-records
+++ b/src/main/resources/sample-data/create-records
@@ -8,15 +8,15 @@ set -a
 set +a
 
 for dir in `echo '
-#    roles
-#    terms
-#    coursetypes
-#    departments
-#    processingstatuses
-#    copyrightstatuses
-#    courselistings
-#    courses
-#    instructors
+    roles
+    terms
+    coursetypes
+    departments
+    processingstatuses
+    copyrightstatuses
+    courselistings
+    courses
+    instructors
     reserves
 ' | grep -v '^[ ]*#'`;
     do


### PR DESCRIPTION
This is the third PR by which I have attempted this trivial task.