### PR TITLE
Add inventory-storage.items.collection.get as a modulePermission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -90,7 +90,7 @@
                     "methods": [ "POST" ],
                     "pathPattern": "/coursereserves/courselistings/{id}/reserves",
                     "permissionsRequired": ["course-reserves-storage.courselistings.reserves.item.post"],
-                    "modulePermissions": ["inventory-storage.items.item.put"]
+                    "modulePermissions": ["inventory-storage.items.item.put", "inventory-storage.items.collection.get"]
                 },
                 {
                     "methods": [ "GET" ],


### PR DESCRIPTION
This is furnished to the operation

	POST /coursereserves/courselistings/{id}/reserves

alongside the existing module permission `inventory-storage.items.item.put`

It should suffice to fix UICR-61.