### PR TITLE
Added Instance HRID to copiedItem

### DIFF
--- a/ramls/reserve.json
+++ b/ramls/reserve.json
@@ -150,6 +150,10 @@
                     "type": "string",
                     "description": "The id of the associated instance record"
                 },
+                "instanceHrid": {
+                    "type": "string",
+                    "description": "The HRID of the associated instance record"
+                },
                 "holdingsId": {
                     "type": "string",
                     "description": "The id of the associated holdings record"

--- a/src/main/java/org/folio/coursereserves/util/CRUtil.java
+++ b/src/main/java/org/folio/coursereserves/util/CRUtil.java
@@ -214,6 +214,7 @@ public class CRUtil {
     copiedItem.setTitle(instanceJson.getString("title"));
     copiedItem.setEnumeration(itemJson.getString("enumeration"));
     copiedItem.setInstanceId(instanceJson.getString("id"));
+    copiedItem.setInstanceHrid(instanceJson.getString("hrid"));
     copiedItem.setHoldingsId(holdingsJson.getString("id"));
     try {
       if (itemJson.containsKey("copyNumber")) {

--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -311,7 +311,7 @@ public class CourseAPITest {
     Async async = context.async();
     async.complete();
   }
-  
+
   @Test
   public void testOkapiReset(TestContext context) {
     Async async = context.async();
@@ -691,7 +691,7 @@ public class CourseAPITest {
                   for(int i = 0; i < instructorObjects.size(); i++) {
                     JsonObject instructorObjectJson = instructorObjects.getJsonObject(i);
                     JsonObject patronGroupObject = instructorObjectJson.getJsonObject("patronGroupObject");
-                    if(patronGroupObject != null && 
+                    if(patronGroupObject != null &&
                       patronGroupObject.getString("id").equals(OkapiMock.group1Id)) {
                       found = true;
                       break;
@@ -713,7 +713,7 @@ public class CourseAPITest {
       }
     });
   }
-  
+
   @Test
   public void postReserveToCourseListing(TestContext context) {
     Async async = context.async();
@@ -725,13 +725,13 @@ public class CourseAPITest {
         .put("copyrightTracking", new JsonObject()
           .put("copyrightStatusId", COPYRIGHT_STATUS_1_ID));
     TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
-        "/reserves", POST, standardHeaders, reservePostJson.encode(), 201, 
+        "/reserves", POST, standardHeaders, reservePostJson.encode(), 201,
         "Post Course Reserve").setHandler(res -> {
       if(res.failed()) {
          context.fail(res.cause());
        } else {
         JsonObject reserveJson = res.result().getJson();
-        if(!reserveJson.containsKey("copiedItem") || 
+        if(!reserveJson.containsKey("copiedItem") ||
             reserveJson.getJsonObject("copiedItem") == null) {
           context.fail("No copiedItem field found");
           return;
@@ -767,6 +767,7 @@ public class CourseAPITest {
                 JsonObject getReserveJson = getRes.result().getJson();
                 JsonObject getCopiedItemJson = getReserveJson.getJsonObject("copiedItem");
                 context.assertEquals(getCopiedItemJson.getString("instanceId"), OkapiMock.instance1Id);
+                context.assertEquals(getCopiedItemJson.getString("instanceHrid"), OkapiMock.instance1Hrid);
                 context.assertEquals(getCopiedItemJson.getString("holdingsId"), OkapiMock.holdings1Id);
                 JsonObject permanentLocationJson = getCopiedItemJson.getJsonObject("permanentLocationObject");
                 JsonObject temporaryLocationJson = getCopiedItemJson.getJsonObject("temporaryLocationObject");
@@ -780,7 +781,7 @@ public class CourseAPITest {
                 if(!permanentLocationJson.getString("id").equals(OkapiMock.location1Id)) {
                   context.fail("Expected permanentLocationObject with id " + OkapiMock.location1Id);
                   return;
-                }                
+                }
                 if(!temporaryLocationJson.getString("id").equals(OkapiMock.location2Id)) {
                   context.fail("Expected temporaryLocationObject with id " + OkapiMock.location2Id);
                   return;
@@ -869,7 +870,7 @@ public class CourseAPITest {
                 reserveJson.getString("itemId"));
           }
           JsonObject copiedItemJson = reserveJson.getJsonObject("copiedItem");
-         
+
           if(! copiedItemJson.getString("barcode").equals(OkapiMock.barcode1)) {
             context.fail("Expected barcode " + OkapiMock.barcode1 + " got " +
                 copiedItemJson.getString("barcode"));
@@ -980,7 +981,7 @@ public class CourseAPITest {
       if(res.failed()) {
          context.fail(res.cause());
        } else {
-        
+
           async.complete();
       }
     });
@@ -1052,7 +1053,7 @@ public class CourseAPITest {
       if(res.failed()) {
          context.fail(res.cause());
        } else {
-        
+
         async.complete();
       }
     });
@@ -1217,7 +1218,7 @@ public class CourseAPITest {
               if(expandRes.failed()) {
                 context.fail(expandRes.cause());
               } else {
-                for(Reserve reserve : expandRes.result()) {                  
+                for(Reserve reserve : expandRes.result()) {
                   if(reserve.getProcessingStatusObject() == null) {
                     context.fail("Expected processing status object to be populated");
                     return;
@@ -1239,7 +1240,7 @@ public class CourseAPITest {
       }
     });
   }
-  
+
 
   @Test
   public void postReservesToCourseListingTestRetrievalAPI(TestContext context) {
@@ -1510,7 +1511,7 @@ public class CourseAPITest {
       }
     });
   }
-  
+
   @Test
   public void loadAndRetrieveCourseListingWithLocation(TestContext context) {
     Async async = context.async();
@@ -1554,9 +1555,9 @@ public class CourseAPITest {
               async.complete();
             }
           }
-        });   
+        });
   }
-  
+
   @Test
   public void loadAndRetrieveCourseListingWithNonExistantLocation(TestContext context) {
     Async async = context.async();
@@ -1599,7 +1600,7 @@ public class CourseAPITest {
           }
         });
   }
-  
+
   @Test
   public void loadAndRetrieveCourseListingWithServicePoint(TestContext context) {
     Async async = context.async();
@@ -1611,7 +1612,7 @@ public class CourseAPITest {
         .put("externalId", UUID.randomUUID().toString())
         .put("servicepointId", OkapiMock.servicePoint1Id);
     Future<WrappedResponse> clFuture = TestUtil.doRequest(vertx, baseUrl + "/courselistings",
-        POST, standardHeaders, courseListingJson.encode(), 201, 
+        POST, standardHeaders, courseListingJson.encode(), 201,
         "Post CourseListing With Service Point")
           .compose(res -> {
               JsonObject courseJson = new JsonObject()
@@ -1649,9 +1650,9 @@ public class CourseAPITest {
             }
           }
         });
-   
+
   }
-  
+
   @Test
   public void loadAndRetrieveCourseListingWithNonExistantServicepoint(TestContext context) {
     Async async = context.async();
@@ -1753,7 +1754,7 @@ public class CourseAPITest {
         "Post Course Reserve").setHandler(postRes -> {
       if(postRes.failed()) {
          context.fail(postRes.cause());
-       } else {       
+       } else {
         TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
         "/reserves/" + reserveId, GET, standardHeaders, null, 200, "Get reserve")
             .setHandler(getRes -> {
@@ -1761,10 +1762,10 @@ public class CourseAPITest {
             context.fail(getRes.cause());
           } else {
             TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
-                "/reserves", DELETE, standardHeaders, null, 204, 
+                "/reserves", DELETE, standardHeaders, null, 204,
                 "Delete reserves with courselisting " + COURSE_LISTING_1_ID)
                 .setHandler(deleteRes -> {
-              if(deleteRes.failed()) { 
+              if(deleteRes.failed()) {
                 context.fail(deleteRes.cause());
               } else {
                 TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
@@ -1777,7 +1778,7 @@ public class CourseAPITest {
                      async.complete();
                    }
                  });
-              }     
+              }
             });
           }
         });
@@ -1851,9 +1852,9 @@ public class CourseAPITest {
         .put("id", instructorId)
         .put("name", "Johann Brown")
         .put("courseListingId", COURSE_LISTING_1_ID);
-    String postUrl = baseUrl + "/courselistings/" + COURSE_LISTING_1_ID 
+    String postUrl = baseUrl + "/courselistings/" + COURSE_LISTING_1_ID
         + "/instructors";
-    String getUrl = baseUrl + "/courselistings/" + COURSE_LISTING_1_ID 
+    String getUrl = baseUrl + "/courselistings/" + COURSE_LISTING_1_ID
         + "/instructors/" + instructorId;
     String putUrl = getUrl;
     String deleteUrl = getUrl;
@@ -2188,8 +2189,8 @@ public class CourseAPITest {
      }, vertx.getOrCreateContext());
    }
    */
-   
-   
+
+
 
    @Test
    public void testGetPGClient(TestContext context) {
@@ -2719,7 +2720,7 @@ public class CourseAPITest {
    });
   }
   */
-  
+
    @Test
    public void testPutEmptyLocationIdToCourseListing(TestContext context) {
      Async async = context.async();
@@ -2942,10 +2943,10 @@ public class CourseAPITest {
       context.assertTrue(f.getJson().getJsonArray("instructorObjects").size() > 1);
       JsonObject clJson = f.getJson();
       clJson.put("termId", TERM_2_ID);
-      
+
       return TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID,
         PUT, acceptTextHeaders, clJson.encode(), 204, "Modify course listing");
-      
+
       //return Future.succeededFuture(f);
     }).compose(f -> {
       return TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID,
@@ -2998,7 +2999,7 @@ public class CourseAPITest {
     });
   }
 
-  
+
   @Test
   public void testAddReserveWithTemporaryLoanType(TestContext context) {
     Async async = context.async();
@@ -3024,7 +3025,7 @@ public class CourseAPITest {
       return TestUtil.doOkapiRequest(vertx, "/item-storage/items/" + itemId,
           GET, okapiHeaders, null, null, 200, "Get item record");
     }).compose(f -> {
-      context.assertEquals(OkapiMock.loanType1Id, 
+      context.assertEquals(OkapiMock.loanType1Id,
             f.getJson().getString("temporaryLoanTypeId"));
       reservePostJson.put("temporaryLoanTypeId", OkapiMock.loanType2Id);
       return TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
@@ -3037,12 +3038,12 @@ public class CourseAPITest {
       if(res.failed()) {
         context.fail(res.cause());
       } else {
-        context.assertEquals(OkapiMock.loanType2Id, 
+        context.assertEquals(OkapiMock.loanType2Id,
             res.result().getJson().getString("temporaryLoanTypeId"));
         async.complete();
       }
     });
-  
+
   }
 
    @Test
@@ -3432,12 +3433,12 @@ public class CourseAPITest {
       }
     });
   }
-  
-
-  
 
 
-  
+
+
+
+
   /* UTILITY METHODS */
 
   private Future<Void> testPostGetPutDelete(JsonObject originalJson, JsonObject modifiedJson,
@@ -3481,12 +3482,12 @@ public class CourseAPITest {
           return TestUtil.doRequest(vertx, deleteAllUrl, DELETE, acceptTextHeaders, null,
               204, "Delete all at " + deleteAllUrl);
         })
- 
+
         .compose(f -> {
           return TestUtil.doRequest(vertx, getUrl, GET, standardHeaders, null, 404,
               "Get from " + getUrl + " after delete all");
         })
-       
+
         .setHandler(res -> {
           if(res.failed()) {
             future.fail(res.cause());
@@ -3515,7 +3516,7 @@ public class CourseAPITest {
         });
     return future;
   }
-   
+
   private Future<Void> loadCourseListing1Instructor2() {
     Future<Void> future = Future.future();
     JsonObject departmentJson = new JsonObject()
@@ -3534,7 +3535,7 @@ public class CourseAPITest {
         });
     return future;
   }
-  
+
     private Future<Void> loadCourseListing2Instructor3() {
     Future<Void> future = Future.future();
     JsonObject departmentJson = new JsonObject()
@@ -4033,7 +4034,7 @@ public class CourseAPITest {
 
 
 class CourseAPIFail extends CourseAPI {
-  
+
   public <T> Future<Results<T>> getItems(String tableName, Class<T> clazz,
       CQLWrapper cql, PostgresClient pgClient) {
     logger.info("Calling Always-Fails getItems");
@@ -4053,7 +4054,7 @@ class CourseAPIFail extends CourseAPI {
     Future future = Future.failedFuture("IT ALWAYS FAILS");
     return future;
   }
-  
+
 }
 
 class CourseAPIWTF extends CourseAPI {

--- a/src/test/java/CourseAPITest/OkapiMock.java
+++ b/src/test/java/CourseAPITest/OkapiMock.java
@@ -37,6 +37,7 @@ public class OkapiMock extends AbstractVerticle {
   public static String holdings1Id = UUID.randomUUID().toString();
   public static String holdings2Id = UUID.randomUUID().toString();
   public static String instance1Id = UUID.randomUUID().toString();
+  public static String instance1Hrid = "inst000000000006";
   public static String barcode1 = "326547658598";
   public static String barcode2 = "539311253355";
   public static String barcode3 = "794630622287";
@@ -169,7 +170,7 @@ public class OkapiMock extends AbstractVerticle {
         return;
       }
    }
-   
+
   private void handleItems(RoutingContext context) {
     logger.info("Got request for items: " + context.request().absoluteURI());
     String id = context.request().getParam("id");
@@ -276,7 +277,7 @@ public class OkapiMock extends AbstractVerticle {
        return null;
      }
    }
-   
+
    private void handleHoldings(RoutingContext context) {
      String id = context.request().getParam("id");
      if(context.request().method() == HttpMethod.GET) {
@@ -301,7 +302,7 @@ public class OkapiMock extends AbstractVerticle {
         return;
       }
    }
-   
+
    private void handleInstances(RoutingContext context) {
      String id = context.request().getParam("id");
      if(context.request().method() == HttpMethod.GET) {
@@ -326,7 +327,7 @@ public class OkapiMock extends AbstractVerticle {
         return;
       }
    }
-   
+
    private void handleLocations(RoutingContext context) {
      logger.info("Got location request");
      String id = context.request().getParam("id");
@@ -352,7 +353,7 @@ public class OkapiMock extends AbstractVerticle {
         return;
       }
    }
-   
+
    private void handleServicePoints(RoutingContext context) {
      logger.info("Got service points request");
      String id = context.request().getParam("id");
@@ -579,7 +580,6 @@ public class OkapiMock extends AbstractVerticle {
       .put("permanentLocationId", location1Id)
       .put("temporaryLocationId", location2Id)
       .put("callNumber", fullCallNumber1)
-      
     );
 
     holdingsMap.put(holdings2Id, new JsonObject()
@@ -600,6 +600,7 @@ public class OkapiMock extends AbstractVerticle {
     instanceMap = new HashMap<>();
     instanceMap.put(instance1Id, new JsonObject()
       .put("id", instance1Id)
+      .put("hrid", instance1Hrid)
       .put("title", title1)
       .put("contributors", new JsonArray()
         .add(new JsonObject()
@@ -635,7 +636,7 @@ public class OkapiMock extends AbstractVerticle {
           .add(servicePoint1Id)
           .add(servicePoint2Id)
           .add(servicePoint3Id)
-        )        
+        )
     );
 
     locationMap.put(location2Id, new JsonObject()
@@ -653,7 +654,7 @@ public class OkapiMock extends AbstractVerticle {
           .add(servicePoint3Id)
         )
     );
-    
+
     servicePointMap = new HashMap<>();
     servicePointMap
       .put(servicePoint1Id, new JsonObject()
@@ -681,7 +682,7 @@ public class OkapiMock extends AbstractVerticle {
           )
         )
     );
-    
+
     servicePointMap.put(servicePoint2Id, new JsonObject()
       .put("id", servicePoint2Id)
       .put("name", "Circ Desk 2")
@@ -734,7 +735,7 @@ public class OkapiMock extends AbstractVerticle {
       .put("id", loanType1Id)
       .put("name", "Reserved Loan")
     );
-        
+
   }
 
   private static void addSampleData() {


### PR DESCRIPTION
First off, sorry about the whitespace, I always have trim-whitespace-on-save enabled. 😆 

Anyway, it does what it says on the tin. We're working on an [Edge API](https://github.com/doytch/edge-lti-courses) that will have URLs for the course reserves that point to patron-accessible sites. SMEs have requested that those URLs be templatable with not just the item barcode, but also instance HRID.