### PR TITLE
Added modulePermissions to PUT reserves route

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -121,7 +121,14 @@
                 {
                     "methods": [ "PUT" ],
                     "pathPattern": "/coursereserves/courselistings/{id}/reserves/{r_id}",
-                    "permissionsRequired": ["course-reserves-storage.courselistings.reserves.item.put"]
+                    "permissionsRequired": ["course-reserves-storage.courselistings.reserves.item.put"],
+                    "modulePermissions": [
+                        "inventory-storage.items.item.put",
+                        "inventory-storage.items.item.get",
+                        "inventory-storage.items.collection.get",
+                        "inventory-storage.holdings.item.get",
+                        "inventory-storage.instances.item.get"
+                    ]
                 },
                 {
                     "methods": [ "DELETE" ],


### PR DESCRIPTION
PUT does the same instance/item/holding lookups as POST to add the reserve info, so it needs the same permissions.

This was discovered when attempting to edit a reserve using a user that only had add/edit permissions via [the `ui-courses.add-edit-items` permission](https://github.com/folio-org/ui-courses/blob/633cae7a2f81b164dcca55eed483a46b18360c07/package.json#L113). Theoretically this could also be accomplished in ui-courses' permission sets, but I figured that mirroring the implementation of the solution for the POST endpoint was preferable.