### PR TITLE
MODCR-62: Item barcode search: CQL injection, use index, punctuation

### DIFF
--- a/src/main/java/org/folio/coursereserves/util/CRUtil.java
+++ b/src/main/java/org/folio/coursereserves/util/CRUtil.java
@@ -508,7 +508,7 @@ public class CRUtil {
       Map<String, String> okapiHeaders, Context context) {
 
     String query = "barcode==" + StringUtil.cqlEncode(barcode);
-    // TODO: replace StringUtil.urlEncode by StringUtil.urlEncode after upgrading to RMB 33
+    // TODO: replace StringUtil.urlEncode by PercentCodec.encode after upgrading to RMB 33
     String itemRequestUrl = ITEMS_ENDPOINT + "?query=" + StringUtil.urlEncode(query);
     logger.debug("Looking up item by barcode with url " + itemRequestUrl);
     return makeOkapiRequest(context.owner(), okapiHeaders, itemRequestUrl, HttpMethod.GET,

--- a/src/test/java/CourseAPITest/OkapiMock.java
+++ b/src/test/java/CourseAPITest/OkapiMock.java
@@ -1,7 +1,6 @@
 package CourseAPITest;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
@@ -17,6 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.folio.util.StringUtil;
 
 
 public class OkapiMock extends AbstractVerticle {
@@ -271,8 +271,8 @@ public class OkapiMock extends AbstractVerticle {
   }
 
    private static String parseBarcode(String query) {
-     Pattern pattern = Pattern.compile("barcode=(\\d+)");
-     Matcher matcher = pattern.matcher(query);
+     Pattern pattern = Pattern.compile("barcode==\"(\\d+)\"");
+     Matcher matcher = pattern.matcher(StringUtil.urlDecode(query));
      if(matcher.find()) {
        return matcher.group(1);
      } else {
@@ -530,7 +530,7 @@ public class OkapiMock extends AbstractVerticle {
       .put("barcode", barcode4)
       .put("active", Boolean.TRUE));
 
-    
+
     groupMap.put(group1Id, new JsonObject()
       .put("id", group1Id)
       .put("name", "wrasslers")
@@ -548,7 +548,7 @@ public class OkapiMock extends AbstractVerticle {
       .put("name", "managers")
       .put("desc", "People Who manage")
     );
-    
+
     itemMap.put(item1Id, new JsonObject()
         .put("id", item1Id)
         .put("status", new JsonObject().put("name", "Available"))
@@ -610,7 +610,7 @@ public class OkapiMock extends AbstractVerticle {
       .put("permanentLocationId", location2Id)
       .put("copyNumbers", new JsonArray()
           .add(copy1))
-    );    
+    );
 
     holdingsMap.put(holdings1Id, new JsonObject()
       .put("id", holdings1Id)


### PR DESCRIPTION
CRUtil.lookupItemByBarcode uses
`barcode=$barcode`

This allows CQL injection if $barcode is `*&limit=9999999`

CQL and percent encoding should be used.

The `=` operator (single equals) is the full text search that ignores punctuation, but barcode may contain punctuation.

The `==` operator (two equals) should be used instead, it is an exact match search that is backed by a database index and is fast.

See also https://dev.folio.org/faqs/explain-cql/