### PR TITLE
MODCR-59: item, instande, holding _version optimistic locking

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -432,15 +432,15 @@
     "requires" : [
         {
             "id" : "item-storage",
-            "version": "7.0 8.0"
+            "version": "7.0 8.0 9.0"
         },
         {
             "id" : "instance-storage",
-            "version": "7.2"
+            "version": "7.2 8.0"
         },
         {
             "id" : "holdings-storage",
-            "version": "2.0 3.0 4.0"
+            "version": "2.0 3.0 4.0 5.0"
         },
         {
             "id" : "locations",

--- a/src/main/java/org/folio/rest/impl/CourseAPI.java
+++ b/src/main/java/org/folio/rest/impl/CourseAPI.java
@@ -1407,7 +1407,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
               if(resetRes.failed()) {
                 logger.error("Unable to delete item '" + reserve.getItemId() +
                     "', " + resetRes.cause().getLocalizedMessage());
-              } 
+              }
               deleteItem(RESERVES_TABLE, reserveId, okapiHeaders, vertxContext)
                   .onComplete(deleteRes -> {
                 if(deleteRes.failed()) {
@@ -1415,7 +1415,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
                 } else {
                   promise.complete();
                 }
-              });              
+              });
             });
           }
         } catch(Exception e) {
@@ -1472,7 +1472,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
             String capField = singleField.substring(0, 1).toUpperCase() +
                 singleField.substring(1);
             if(i == subFieldArray.length - 1) {
-              String setterMethodName = "set" + capField;              
+              String setterMethodName = "set" + capField;
               Method setterMethod = getMethodByName(currentObject, setterMethodName);
               if(setterMethod != null) {
                 logger.debug("Calling set method " + setterMethod.getName() + " ("+
@@ -1481,17 +1481,17 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
               }
               break;
             } else {
-              String getterMethodName = "get" + capField;              
+              String getterMethodName = "get" + capField;
               Method getterMethod = getMethodByName(currentObject, getterMethodName);
               if(getterMethod != null) {
                 logger.debug("Calling get method " + getterMethod.getName());
                 currentObject = getterMethod.invoke(currentObject);
               } else {
                 break;
-              }              
+              }
             }
           }
-        }        
+        }
       } catch(Exception e) {
         String currentObjectClassName
             = currentObject != null ? currentObject.getClass().getName() : "<null>";
@@ -1581,7 +1581,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
          * in the reserve if one exists in the courseListing. We do not want the override
          * for a PUT operation
          */
-        if(writeType == WriteType.POST && 
+        if(writeType == WriteType.POST &&
           originalTemporaryLocationId == null && courseListingLocation != null) {
           logger.info("Using courseListing location for reserve temporary location");
           originalTemporaryLocationId = courseListingLocation;
@@ -1639,7 +1639,7 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
                   } else {
                     putFuture = Future.succeededFuture();
                   }
-                  putFuture.onComplete(putRes -> {
+                  putFuture.<Void>map(x -> {
                     //We need to set the temporary location if it exists
                     if(finalOriginalTemporaryLocationId != null && entity.getCopiedItem() != null) {
                       entity.getCopiedItem().setTemporaryLocationId(finalOriginalTemporaryLocationId);
@@ -1655,6 +1655,13 @@ public class CourseAPI implements org.folio.rest.jaxrs.resource.Coursereserves {
                           PutCoursereservesCourselistingsReservesByListingIdAndReserveIdResponse.class,
                           asyncResultHandler);
                     }
+                    return null;
+                  })
+                  .onFailure(e -> {
+                    String message = logAndSaveError(e);
+                    asyncResultHandler.handle(Future.succeededFuture(
+                        PostCoursereservesCourselistingsReservesByListingIdResponse
+                        .respond500WithTextPlain(getErrorResponse(message))));
                   });
                 } catch(Exception e) {
                   String message = logAndSaveError(e);

--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -1,6 +1,7 @@
 package CourseAPITest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 
 import CourseAPITest.TestUtil.WrappedResponse;
@@ -980,6 +981,24 @@ public class CourseAPITest {
             });
       }
     });
+  }
+
+  @Test
+  public void postReserveToCourseListingPutItemFails(TestContext context) {
+    JsonObject reservePostJson = new JsonObject()
+        .put("courseListingId", COURSE_LISTING_1_ID)
+        .put("temporaryLoanTypeId", OkapiMock.loanType1Id)
+        .put("processingStatusId", PROCESSING_STATUS_1_ID)
+        .put("copyrightTracking", new JsonObject()
+            .put("copyrightStatusId", COPYRIGHT_STATUS_1_ID))
+        .put("copiedItem", new JsonObject()
+            .put("barcode", OkapiMock.barcode7));  // this triggers item PUT failure
+    TestUtil.doRequest(vertx, baseUrl + "/courselistings/" + COURSE_LISTING_1_ID +
+        "/reserves", POST, standardHeaders, reservePostJson.encode(), 500,
+        "Post Course Reserve")
+    .onComplete(context.asyncAssertSuccess(wrappedResponse -> {
+      assertThat(wrappedResponse.getBody(), containsString("We've mocked barcode 0 to fail on PUT"));
+    }));
   }
 
   @Test

--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -2220,37 +2220,25 @@ public class CourseAPITest {
 
    @Test
    public void testPutToItem(TestContext context) {
-     Async async = context.async();
      String itemId = OkapiMock.item1Id;
      String newBarcode = "1112223334";
      JsonObject newItem = new JsonObject()
          .put("id", itemId)
+         .put("_version", 6)
          .put("status", new JsonObject().put("name", "Available"))
-        .put("holdingsRecordId", OkapiMock.holdings1Id)
-        .put("barcode",newBarcode)
-        .put("volume", OkapiMock.volume1)
-        .put("enumeration", OkapiMock.enumeration1)
-        .put("copyNumber", OkapiMock.copy1)
-        .put("electronicAccess", new JsonArray()
-          .add(new JsonObject()
-            .put("uri", OkapiMock.uri1)
-            .put("publicNote", OkapiMock.uri1))
-          );
+         .put("holdingsRecordId", OkapiMock.holdings1Id)
+         .put("barcode",newBarcode)
+         .put("volume", OkapiMock.volume1)
+         .put("enumeration", OkapiMock.enumeration1)
+         .put("copyNumber", OkapiMock.copy1)
+         .put("electronicAccess", new JsonArray()
+             .add(new JsonObject()
+                 .put("uri", OkapiMock.uri1)
+                 .put("publicNote", OkapiMock.uri1))
+             );
      CRUtil.putItemUpdate(newItem, okapiHeaders, vertx.getOrCreateContext())
-         .onComplete(putRes -> {
-       if(putRes.failed()) {
-         context.fail(putRes.cause());
-       } else {
-         CRUtil.lookupItemHoldingsInstanceByItemId(itemId, okapiHeaders,
-             vertx.getOrCreateContext()).onComplete(getRes -> {
-           if(getRes.failed()) {
-             context.fail(getRes.cause());
-           } else {
-             async.complete();
-           }
-         });
-       }
-     });
+     .compose(x -> CRUtil.lookupItemHoldingsInstanceByItemId(itemId, okapiHeaders, vertx.getOrCreateContext()))
+     .onComplete(context.asyncAssertSuccess());
    }
 
    @Test

--- a/src/test/java/CourseAPITest/OkapiMock.java
+++ b/src/test/java/CourseAPITest/OkapiMock.java
@@ -34,6 +34,8 @@ public class OkapiMock extends AbstractVerticle {
   public static String item4Id = UUID.randomUUID().toString();
   public static String item5Id = UUID.randomUUID().toString();
   public static String item6Id = UUID.randomUUID().toString();
+  /** item where PUT fails */
+  public static String item7Id = UUID.randomUUID().toString();
   public static String holdings1Id = UUID.randomUUID().toString();
   public static String holdings2Id = UUID.randomUUID().toString();
   public static String instance1Id = UUID.randomUUID().toString();
@@ -42,6 +44,8 @@ public class OkapiMock extends AbstractVerticle {
   public static String barcode2 = "539311253355";
   public static String barcode3 = "794630622287";
   public static String barcode4 = "229842532165";
+  /** barcode of item where PUT fails */
+  public static String barcode7 = "0";
   public static String location1Id = UUID.randomUUID().toString();
   public static String location2Id = UUID.randomUUID().toString();
   public static String fullCallNumber1 = "D15.H63 A3 2002";
@@ -227,6 +231,11 @@ public class OkapiMock extends AbstractVerticle {
         }
         if (6 != putJson.getInteger("_version")) {  // optimistic locking
           throw new IllegalArgumentException("_version must be 6 in putJson: " + putJson.encodePrettily());
+        }
+        if ("0".equals(putJson.getString("barcode"))) {
+          context.response().setStatusCode(500)
+              .end("We've mocked barcode 0 to fail on PUT");
+          return;
         }
         logger.info("Writing JSON back to mapping");
         itemMap.put(id, putJson);
@@ -617,6 +626,12 @@ public class OkapiMock extends AbstractVerticle {
       .put("permanentLocationId", location2Id)
       .put("copyNumbers", new JsonArray()
           .add(copy1))
+    );
+
+    itemMap.put(item7Id, itemMap
+        .get(item1Id).copy()
+        .put("id", item7Id)
+        .put("barcode", barcode7)
     );
 
     holdingsMap.put(holdings1Id, new JsonObject()


### PR DESCRIPTION
Allow additional versions for required inventory interfaces:

* item-storage 9.0
* instance-storage 8.0
* holdings-storage 4.0

They add the `_version` property for optimistic locking.

mod-courses uses only one inventory writing API: item PUT.

Error handling code is added to CoursAPI.handleWriteReserves
to handle an item PUT failure.

OkapiMock is extended to always return items with `_version`=6
and checks that item PUT is called with `_version`=6.