### PR TITLE
Reset using CourseAPI.setSuppressErrors(false)

### DIFF
--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -116,7 +116,6 @@ public class CourseAPITest {
     standardHeaders.add("x-okapi-url", okapiUrl);
     acceptTextHeaders.add("accept", "text/plain");
     acceptTextHeaders.add("x-okapi-url", okapiUrl);
-    CourseAPI.setSuppressErrors(false);
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions()
         .setConfig(new JsonObject().put("http.port", port));

--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -116,6 +116,7 @@ public class CourseAPITest {
     standardHeaders.add("x-okapi-url", okapiUrl);
     acceptTextHeaders.add("accept", "text/plain");
     acceptTextHeaders.add("x-okapi-url", okapiUrl);
+    CourseAPI.setSuppressErrors(false);
     vertx = Vertx.vertx();
     DeploymentOptions options = new DeploymentOptions()
         .setConfig(new JsonObject().put("http.port", port));

--- a/src/test/java/org/folio/rest/impl/CourseAPITest.java
+++ b/src/test/java/org/folio/rest/impl/CourseAPITest.java
@@ -4,12 +4,17 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertTrue;
-import org.z3950.zing.cql.CQLParseException;
+
+import org.junit.After;
+import org.junit.Before;
 
 public class CourseAPITest {
-  
-  
+
+  @Before
+  @After
+  public void cleanUp() {
+    CourseAPI.setSuppressErrors(false);
+  }
 
   @Test
   public void testIsDuplicate() {
@@ -30,5 +35,5 @@ public class CourseAPITest {
     assertFalse(CourseAPI.isCQLError(e));
   }
 
-  
+
 }


### PR DESCRIPTION
Otherwise we may get failures like this:

Expected: a string containing "We've mocked barcode 0 to fail on PUT"
     but: was "An error occurred"

Reason:

src/test/java/org/folio/rest/impl/CourseAPITest.java has a test that disables error messages but forgot to re-enable it after the test. If
src/test/java/org/folio/rest/impl/CourseAPITest.java runs before
src/test/java/CourseAPITest/CourseAPITest.java the test fails, otherwise it succeeds.