### PR TITLE
MODCR-65: Add discoverySuppress to copiedItem

### DIFF
--- a/ramls/reserve.json
+++ b/ramls/reserve.json
@@ -154,6 +154,10 @@
                     "type": "string",
                     "description": "The HRID of the associated instance record"
                 },
+                "instanceDiscoverySuppress": {
+                    "type": "boolean",
+                    "description": "Whether the associated instance record has been marked as suppressed from discovery"
+                },
                 "holdingsId": {
                     "type": "string",
                     "description": "The id of the associated holdings record"

--- a/src/main/java/org/folio/coursereserves/util/CRUtil.java
+++ b/src/main/java/org/folio/coursereserves/util/CRUtil.java
@@ -219,6 +219,7 @@ public class CRUtil {
     copiedItem.setEnumeration(itemJson.getString("enumeration"));
     copiedItem.setInstanceId(instanceJson.getString("id"));
     copiedItem.setInstanceHrid(instanceJson.getString("hrid"));
+    copiedItem.setInstanceDiscoverySuppress(instanceJson.getBoolean("discoverySuppress", false));
     copiedItem.setHoldingsId(holdingsJson.getString("id"));
     try {
       if (itemJson.containsKey("copyNumber")) {

--- a/src/test/java/CourseAPITest/CourseAPITest.java
+++ b/src/test/java/CourseAPITest/CourseAPITest.java
@@ -674,6 +674,7 @@ public class CourseAPITest {
                 JsonObject getCopiedItemJson = getReserveJson.getJsonObject("copiedItem");
                 context.assertEquals(getCopiedItemJson.getString("instanceId"), OkapiMock.instance1Id);
                 context.assertEquals(getCopiedItemJson.getString("instanceHrid"), OkapiMock.instance1Hrid);
+                context.assertEquals(getCopiedItemJson.getBoolean("instanceDiscoverySuppress"), OkapiMock.instance1DiscoverySuppress);
                 context.assertEquals(getCopiedItemJson.getString("holdingsId"), OkapiMock.holdings1Id);
                 JsonObject permanentLocationJson = getCopiedItemJson.getJsonObject("permanentLocationObject");
                 JsonObject temporaryLocationJson = getCopiedItemJson.getJsonObject("temporaryLocationObject");

--- a/src/test/java/CourseAPITest/OkapiMock.java
+++ b/src/test/java/CourseAPITest/OkapiMock.java
@@ -41,6 +41,7 @@ public class OkapiMock extends AbstractVerticle {
   public static String holdings2Id = UUID.randomUUID().toString();
   public static String instance1Id = UUID.randomUUID().toString();
   public static String instance1Hrid = "inst000000000006";
+  public static Boolean instance1DiscoverySuppress = true;
   public static String barcode1 = "326547658598";
   public static String barcode2 = "539311253355";
   public static String barcode3 = "794630622287";
@@ -659,6 +660,7 @@ public class OkapiMock extends AbstractVerticle {
     instanceMap.put(instance1Id, new JsonObject()
       .put("id", instance1Id)
       .put("hrid", instance1Hrid)
+      .put("discoverySuppress", instance1DiscoverySuppress)
       .put("title", title1)
       .put("contributors", new JsonArray()
         .add(new JsonObject()


### PR DESCRIPTION
[MODCR-65](https://issues.folio.org/browse/MODCR-65): Pull the instance's `discoverySuppress` into the `copiedItem`