### PR TITLE
MODCR-66: CQL/SQL injection courseListingId

### DIFF
--- a/ramls/courses.raml
+++ b/ramls/courses.raml
@@ -68,6 +68,11 @@ resourceTypes:
             responses:
                 204:
                     description: "All listings deleted"
+                400:
+                    description: "Bad request, e.g. unknown tenant"
+                    body:
+                      text/plain:
+                        example: tenant not found
                 500:
                     description: "Internal server error"
                     body:
@@ -106,6 +111,11 @@ resourceTypes:
                     responses:
                         204:
                             description: "All courses deleted"
+                        400:
+                            description: "Bad request, e.g. malformed listing_id"
+                            body:
+                              text/plain:
+                                example: listing_id is not a UUID
                         500:
                             description: "Internal server error"
                             body:
@@ -146,6 +156,11 @@ resourceTypes:
                     responses:
                         204:
                             description: "All instructors deleted"
+                        400:
+                            description: "Bad request, e.g. malformed listing_id"
+                            body:
+                              text/plain:
+                                example: listing_id is not a UUID
                         500:
                             description: "Internal server error"
                             body:
@@ -189,6 +204,11 @@ resourceTypes:
                     responses:
                         204:
                             description: "All reserves deleted"
+                        400:
+                            description: "Bad request, e.g. malformed listing_id"
+                            body:
+                              text/plain:
+                                example: listing_id is not a UUID
                         500:
                             description: "Internal server error"
                             body:
@@ -228,6 +248,11 @@ resourceTypes:
             responses:
                 204:
                     description: "All roles deleted"
+                400:
+                    description: "Bad request, e.g. unknown tenant"
+                    body:
+                      text/plain:
+                        example: "tenant not found"
                 500:
                     description: "Internal server error"
                     body:

--- a/src/test/java/CourseAPITest/TestUtil.java
+++ b/src/test/java/CourseAPITest/TestUtil.java
@@ -6,8 +6,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -192,11 +190,11 @@ public class TestUtil {
             promise.complete(wr);
           }
         } catch(Exception e) {
-          promise.fail(e);
+          promise.tryFail(e);
         }
       }
     });
-    
+
     logger.info("Sending " + method.toString() + " request to url '"+
               uri + " with payload: " + payload + "'\n");
 


### PR DESCRIPTION
CourseAPI.java has this code with CQL injection:

    String.format("courseListingId = %s", listingId)

    String.format("DELETE FROM %s_%s.%s WHERE jsonb->>'courseListingId' = '%s'",
          tenantId, "mod_courses", COURSES_TABLE, listingId);

The listingId variable is used without validation and without
masking of CQL or SQL characters resulting in CQL and SQL injection.

Solution:

Use

    StringUtil.cqlEncode(listingId)

to wrap correctly wrap and encode the linstingId.

For delete use RMB's PgUtil.delete to avoid duplicate code and
to avoid any CQL and SQL injection.

Note that

    courseListingId =

is a full text search and is a wrong operator. Instead

    courseListingId ==

is used to make use of the b-tree index that RMB has automatically
created for this foreign key field.