### PR TITLE
MODCR-89: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -432,15 +432,15 @@
     "requires" : [
         {
             "id" : "item-storage",
-            "version": "7.0 8.0 9.0"
+            "version": "7.0 8.0 9.0 10.0"
         },
         {
             "id" : "instance-storage",
-            "version": "7.2 8.0"
+            "version": "7.2 8.0 9.0"
         },
         {
             "id" : "holdings-storage",
-            "version": "2.0 3.0 4.0 5.0"
+            "version": "2.0 3.0 4.0 5.0 6.0"
         },
         {
             "id" : "locations",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-courses is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-courses.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json