### PR TITLE
MODCR-128 - Upgrade "holdings-storage" API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,5 @@
 ## 1.4.11
-* Upgrade `holdings-storage` to 8.0 ([]())
-
+* Upgrade `holdings-storage` to 8.0 ([MODCR-128](https://folio-org.atlassian.net/browse/MODCR-128))
 
 ## 1.4.10 2024-03-22
 * Correct issue with logging import

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 1.4.11
+* Upgrade `holdings-storage` to 8.0 ([]())
+
+
 ## 1.4.10 2024-03-22
 * Correct issue with logging import
 
@@ -11,7 +15,7 @@
 
 ## 1.4.7 2023-02-24
 * Update to permit use of new inventory-storage interface ([MODCR-103](https://issues.folio.org/projects/MODCR/issues/MODCR-103))
-* Update reference data 
+* Update reference data
 
 ## 1.4.6 2022-10-28
 * Add personal disclosure statement ([MODCR-88](https://issues.folio.org/browse/MODCR-88))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -440,7 +440,7 @@
         },
         {
             "id" : "holdings-storage",
-            "version": "2.0 3.0 4.0 5.0 6.0 7.0"
+            "version": "2.0 3.0 4.0 5.0 6.0 7.0 8.0"
         },
         {
             "id" : "locations",


### PR DESCRIPTION
[MODCR-128](https://folio-org.atlassian.net/browse/MODCR-128)
Upgrade the API version in the ModuleDescriptor-template.json:

-`holdings-storage 8.0`